### PR TITLE
ユーザーアイコン編集機能の実装とアイコンプレビュー

### DIFF
--- a/src/main/java/in/tech_camp/protospace_c/controller/PrototypeController.java
+++ b/src/main/java/in/tech_camp/protospace_c/controller/PrototypeController.java
@@ -113,6 +113,7 @@ public class PrototypeController {
     List<GenreEntity> genres = genreRepository.findAll();
      
     model.addAttribute("genres", genres);
+    model.addAttribute("prototype", prototype);
     model.addAttribute("prototypeForm", prototypeForm);
     model.addAttribute("prototypeId", prototypeId);
     return "prototypes/edit";

--- a/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
@@ -30,6 +30,7 @@ import in.tech_camp.protospace_c.custom_user.CustomUserDetail;
 import in.tech_camp.protospace_c.entity.PrototypeEntity;
 import in.tech_camp.protospace_c.entity.UserEntity;
 import in.tech_camp.protospace_c.form.UserForm;
+import in.tech_camp.protospace_c.form.UserIconForm;
 import in.tech_camp.protospace_c.repository.LikesRepository;
 import in.tech_camp.protospace_c.repository.PrototypeRepository;
 import in.tech_camp.protospace_c.repository.UserRepository;
@@ -37,6 +38,7 @@ import in.tech_camp.protospace_c.service.UserService;
 import in.tech_camp.protospace_c.validation.ValidationOrder;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
+
 
 
 @Controller
@@ -292,19 +294,76 @@ public class UserController {
     @AuthenticationPrincipal CustomUserDetail currentUser) {
       UserEntity user = userRepository.findById(userId);
 
-      UserForm userForm = new UserForm();
-
-      userForm.setNickname(user.getNickname());
-      userForm.setEmail(user.getEmail());
-      userForm.setProfile(user.getProfile());
-      userForm.setAffiliation(user.getAffiliation());
-      userForm.setPosition(user.getPosition());
-      userForm.setPassword(user.getPassword());
-      userForm.setPasswordConfirmation(user.getPassword());
+      UserIconForm userIconForm = new UserIconForm();
 
       model.addAttribute("user", user);
-      model.addAttribute("userForm", userForm);
+      model.addAttribute("userIconForm", userIconForm);
       model.addAttribute("userId", userId);
     return "users/icon_edit";
+  }
+
+  @PostMapping("/users/{userId}/icon-update")
+  public String updateUserIcon(
+    @PathVariable("userId") Integer userId,
+    @ModelAttribute("userIconForm") UserIconForm userIconForm,
+    BindingResult result,
+    @AuthenticationPrincipal CustomUserDetail currentUser,
+    Model model
+  ) {
+    if (result.hasErrors()) {
+      List<String> errorMessages = result.getAllErrors().stream()
+              .map(DefaultMessageSourceResolvable::getDefaultMessage)
+              .collect(Collectors.toList());
+      model.addAttribute("errorMessages", errorMessages);
+
+      model.addAttribute("userIconForm", userIconForm);
+      model.addAttribute("userId", userId);
+      return "users/icon_edit";
+    }
+
+    UserEntity user = userRepository.findById(userId);
+    
+    MultipartFile avatarFile = userIconForm.getAvatar();
+    String avatarPath = null;
+    if (avatarFile != null && !avatarFile.isEmpty()) {
+        try {
+            String uploadDir = imageUrl.getUserAvatarUrl();
+            Path uploadDirPath = Paths.get(uploadDir);
+
+            if (!Files.exists(uploadDirPath)) {
+                Files.createDirectories(uploadDirPath);
+            }
+            String fileName = LocalDateTime.now()
+                                .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + "_" + avatarFile.getOriginalFilename();
+            Path imagePath = uploadDirPath.resolve(fileName);
+            Files.copy(avatarFile.getInputStream(), imagePath);
+            avatarPath = "/user_avatars/" + fileName; 
+        } catch (IOException e) {
+            result.rejectValue("avatar", "upload", "アイコン画像の保存に失敗しました");
+            List<String> errorMessages = result.getAllErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
+            model.addAttribute("errorMessages", errorMessages);
+            model.addAttribute("userIconForm", userIconForm);
+            model.addAttribute("userId", userId);
+            return "users/icon_edit";
+        }
+    } else {
+        avatarPath = user.getAvatar();
+    }
+    user.setAvatar(avatarPath);
+
+    try {
+      userService.updateUserWithEncryptedPassword(user);
+  } catch (Exception e) {
+      model.addAttribute("errorMessage", "保存時にエラーが発生しました：" + e.getMessage());
+      model.addAttribute("user", user);
+      model.addAttribute("userIconForm", userIconForm);
+      model.addAttribute("userId", userId);
+      return "users/icon_edit";
+  }
+
+  // 完了後はマイページへリダイレクト
+  return "redirect:/users/" + userId;
   }
 }

--- a/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
@@ -284,4 +284,26 @@ public class UserController {
       
       return "redirect:/users/" + userId;
   }
+
+  @GetMapping("/users/{userId}/icon-edit")
+  public String showUserIconEdit(
+    @PathVariable("userId") Integer userId, 
+    Model model,
+    @AuthenticationPrincipal CustomUserDetail currentUser) {
+      UserEntity user = userRepository.findById(userId);
+
+      UserForm userForm = new UserForm();
+
+      userForm.setNickname(user.getNickname());
+      userForm.setEmail(user.getEmail());
+      userForm.setProfile(user.getProfile());
+      userForm.setAffiliation(user.getAffiliation());
+      userForm.setPosition(user.getPosition());
+      userForm.setPassword(user.getPassword());
+      userForm.setPasswordConfirmation(user.getPassword());
+
+      model.addAttribute("userForm", userForm);
+      model.addAttribute("userId", userId);
+    return "users/icon_edit";
+  }
 }

--- a/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
@@ -214,6 +214,7 @@ public class UserController {
       userForm.setPassword(user.getPassword());
       userForm.setPasswordConfirmation(user.getPassword());
 
+      model.addAttribute("user", user);
       model.addAttribute("userForm", userForm);
       model.addAttribute("userId", userId);
     

--- a/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
@@ -354,7 +354,7 @@ public class UserController {
     user.setAvatar(avatarPath);
 
     try {
-      userService.updateUserWithEncryptedPassword(user);
+      userRepository.updateIcon(userId, avatarPath);
   } catch (Exception e) {
       model.addAttribute("errorMessage", "保存時にエラーが発生しました：" + e.getMessage());
       model.addAttribute("user", user);

--- a/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_c/controller/UserController.java
@@ -302,6 +302,7 @@ public class UserController {
       userForm.setPassword(user.getPassword());
       userForm.setPasswordConfirmation(user.getPassword());
 
+      model.addAttribute("user", user);
       model.addAttribute("userForm", userForm);
       model.addAttribute("userId", userId);
     return "users/icon_edit";

--- a/src/main/java/in/tech_camp/protospace_c/form/UserIconForm.java
+++ b/src/main/java/in/tech_camp/protospace_c/form/UserIconForm.java
@@ -1,0 +1,10 @@
+package in.tech_camp.protospace_c.form;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Data;
+
+@Data
+public class UserIconForm {
+  private MultipartFile avatar;
+}

--- a/src/main/java/in/tech_camp/protospace_c/repository/UserRepository.java
+++ b/src/main/java/in/tech_camp/protospace_c/repository/UserRepository.java
@@ -45,4 +45,7 @@ public interface UserRepository {
 
   @Update("UPDATE users SET nickname=#{nickname}, email=#{email}, password=#{password}, profile=#{profile}, affiliation=#{affiliation}, position=#{position}, avatar=#{avatar} WHERE id=#{id}")
   void update(UserEntity user);
+
+  @Update("UPDATE users SET avatar=#{avatar} WHERE id=#{id}")
+  void updateIcon(Integer id, String avatar);
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -997,9 +997,17 @@ color: #444;
 /* アイコン編集ページ */
 .user-icon-preview-area {
     margin: 15px 0 50px 0;
-    width: 350px;
     display: flex;
-    flex-direction: column; 
+    flex-direction: row;
+    /* gap: 40px; */
+    align-items: flex-start;
+    justify-content: space-around;
+}
+
+.icon-block {
+    width: 300px;
+    display: flex;
+    flex-direction: column;
     align-items: center;
 }
 
@@ -1012,19 +1020,3 @@ color: #444;
     border: 2px solid #fafafa;
     box-shadow: 0 2px 10px rgba(0,0,0,0.07);
 }
-
-/* .user-icon-area {
-    margin-top: 15px;
-    display: flex;
-    align-items: center;
-}
-
-.user-icon-img {
-    width: 230px;
-    height: 230px;
-    object-fit: cover;
-    border-radius: 50%;
-    background: #eee;
-    border: 2px solid #fafafa;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.07);
-} */

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -274,6 +274,15 @@ body {
   cursor: pointer;
 }
 
+.prototype-image-preview-area {
+    margin: 15px 0 50px 0;
+    width: 350px;
+    display: flex;
+    flex-direction: column; 
+    align-items: center;
+}
+
+
 /* レスポンシブデザイン */
 
 @media (max-width: 1024px) {
@@ -556,9 +565,6 @@ img {
     flex-direction: column;
     align-items: center;
     font-style: oblique;
-
-    /* position: relative;
-    aspect-ratio: 16 / 9; */
 }
 
 .banner-title {
@@ -988,3 +994,37 @@ color: #444;
     color: #fff;
   }
   
+/* アイコン編集ページ */
+.user-icon-preview-area {
+    margin: 15px 0 50px 0;
+    width: 350px;
+    display: flex;
+    flex-direction: column; 
+    align-items: center;
+}
+
+.user-icon-preview {
+    width: 230px;
+    height: 230px;
+    object-fit: cover;
+    border-radius: 50%;
+    background: #eee;
+    border: 2px solid #fafafa;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.07);
+}
+
+/* .user-icon-area {
+    margin-top: 15px;
+    display: flex;
+    align-items: center;
+}
+
+.user-icon-img {
+    width: 230px;
+    height: 230px;
+    object-fit: cover;
+    border-radius: 50%;
+    background: #eee;
+    border: 2px solid #fafafa;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.07);
+} */

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -226,6 +226,24 @@ body {
     color: #87CEFA;
 }
 
+.register-icon-preview-area {
+    width: 400px;
+    margin: 15px 0 50px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.register-icon-preview-img {
+    width: 230px;
+    height: 230px;
+    object-fit: cover;
+    border-radius: 50%;
+    background: #eee;
+    border: 2px solid #fafafa;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.07);
+}
+
 /* 追加分 （style.cssに追記してください）*/
 .form__wrapper {
   min-height: calc(100vh - 161px);

--- a/src/main/resources/static/js/avatar_preview.js
+++ b/src/main/resources/static/js/avatar_preview.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const fileInput = document.getElementById('avatar');
+  const previewImg = document.getElementById('preview-avatar');
+  if(fileInput && previewImg) {
+    fileInput.addEventListener('change', function(e) {
+      const file = e.target.files[0];
+      if (file) {
+        previewImg.style.display = "block";
+        previewImg.src = URL.createObjectURL(file);
+      } else {
+        previewImg.src = "";
+        previewImg.style.display = "none";
+      }
+    });
+  }
+});

--- a/src/main/resources/templates/prototypes/edit.html
+++ b/src/main/resources/templates/prototypes/edit.html
@@ -42,6 +42,11 @@
             </select>
           </div>
 
+          <div class="prototype-image-preview-area">
+            <h2>現在の画像</h2>
+            <img th:src="@{${prototype.image}}" alt="現在の画像" class="prototype-image-preview">
+          </div>
+
           <div class="field">
             <label for="prototype_image">プロトタイプの画像</label><br>
             <input type="file" id="prototype_image" th:field="*{image}" required>

--- a/src/main/resources/templates/users/detail.html
+++ b/src/main/resources/templates/users/detail.html
@@ -25,9 +25,19 @@
       </div>
       <div class="user-detail-area">
         <div class="user-icon-area">
-          <img class="user-icon-img"
-                th:src="@{${thisUser.avatar}}" 
-                alt="ユーザーアイコン">
+          <!-- マイページの場合: 画像に編集ページリンクをつける -->
+          <a th:if="${user != null and thisUser.id == user.id}"
+          th:href="@{/users/{userId}/icon-edit(userId=${user.id})}"
+          class="user-icon-edit-link">
+            <img class="user-icon-img"
+                  th:src="@{${thisUser.avatar}}"
+                  alt="ユーザーアイコン（編集リンク付き）">
+          </a>
+          <!-- 他人のページはリンクなし -->
+          <img th:if="${user == null or thisUser.id != user.id}"
+              class="user-icon-img"
+              th:src="@{${thisUser.avatar}}"
+              alt="ユーザーアイコン">
         </div>
         <table class="table">
           <tbody>

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -65,13 +65,19 @@
         </div>
 
         <div class="user-icon-preview-area">
-          <h2>現在のアイコン</h2>
-          <img th:src="@{${user.avatar}}" alt="現在のアイコン" class="user-icon-preview">
+          <div class="icon-block">
+            <h2>現在のアイコン</h2>
+            <img th:src="@{${user.avatar}}" alt="現在のアイコン" class="user-icon-preview">
+          </div>
+          <div class="icon-block">
+            <h2>アップロード画像</h2>
+            <img id="preview-avatar" src="" alt="アップロード画像" class="user-icon-preview" style="display:none;">
+          </div>
         </div>
 
         <div class="field">
           <label for="prototype_image">アイコンの画像</label><br>
-          <input type="file" id="avatar_image" th:field="*{avatar}">
+          <input type="file" id="avatar" th:field="*{avatar}">
         </div>
 
         <div class="action">
@@ -82,7 +88,7 @@
   </div>
 </main>
 
-
+<script src="/js/avatar_preview.js"></script>
 <div th:insert="~{footer :: footer}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -64,6 +64,11 @@
           <textarea class="text_form" id="position" name="position" th:field="*{position}"></textarea>
         </div>
 
+        <div class="user-icon-preview-area">
+          <h2>現在のアイコン</h2>
+          <img th:src="@{${user.avatar}}" alt="現在のアイコン" class="user-icon-preview">
+        </div>
+
         <div class="field">
           <label for="prototype_image">アイコンの画像</label><br>
           <input type="file" id="avatar_image" th:field="*{avatar}">

--- a/src/main/resources/templates/users/icon_edit.html
+++ b/src/main/resources/templates/users/icon_edit.html
@@ -26,7 +26,7 @@
             th:object="${userIconForm}" 
             method="post" 
             enctype="multipart/form-data">
-        <div class="form_field">
+        <div class="field">
           <label for="avatar">新しいアイコン画像を選択</label>
           <br>
           <input type="file" id="avatar" th:field="*{avatar}" required>
@@ -37,7 +37,7 @@
         </div>
       </form>
 
-      <div>
+      <div class="action">
         <a th:href="@{/users/{userId}(userId=${userId})}" class="nav_btn">マイページへ戻る</a>
       </div>
     </div>

--- a/src/main/resources/templates/users/icon_edit.html
+++ b/src/main/resources/templates/users/icon_edit.html
@@ -14,10 +14,16 @@
     <div class="form_cover">
       <h2 class="heading">ユーザーアイコン編集画面</h2>
 
-      <!-- 現在のアイコン -->
       <div class="user-icon-preview-area">
-        <h2>現在のアイコン</h2>
-        <img th:src="@{${user.avatar}}" alt="現在のアイコン" class="user-icon-preview">
+        <!-- 現在のアイコン -->
+        <div class="icon-block">
+          <h2>現在のアイコン</h2>
+          <img th:src="@{${user.avatar}}" alt="現在のアイコン" class="user-icon-preview">
+        </div>
+        <div class="icon-block">
+          <h2>アップロード画像</h2>
+          <img id="preview-avatar" src="" alt="アップロード画像" class="user-icon-preview" style="display:none;">
+        </div>
       </div>
 
       <!-- アップロードフォーム -->
@@ -43,6 +49,7 @@
   </div>
 </main>
 
+<script src="/js/avatar_preview.js"></script>
 <div th:insert="~{footer :: footer}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/users/icon_edit.html
+++ b/src/main/resources/templates/users/icon_edit.html
@@ -23,7 +23,7 @@
 
       <!-- アップロードフォーム -->
       <form th:action="@{/users/{userId}/icon-update(userId=${userId})}" 
-            th:object="${userForm}" 
+            th:object="${userIconForm}" 
             method="post" 
             enctype="multipart/form-data">
         <div class="form_field">

--- a/src/main/resources/templates/users/icon_edit.html
+++ b/src/main/resources/templates/users/icon_edit.html
@@ -13,12 +13,11 @@
   <div class="inner">
     <div class="form_cover">
       <h2 class="heading">ユーザーアイコン編集画面</h2>
-      <br>
-      <br>
 
       <!-- 現在のアイコン -->
-      <div>
-        <img th:src="@{${user.avatar}}" alt="現在のアイコン">
+      <div class="user-icon-preview-area">
+        <h2>現在のアイコン</h2>
+        <img th:src="@{${user.avatar}}" alt="現在のアイコン" class="user-icon-preview">
       </div>
 
       <!-- アップロードフォーム -->

--- a/src/main/resources/templates/users/icon_edit.html
+++ b/src/main/resources/templates/users/icon_edit.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ProtoSpace</title>
+  <link th:href="@{/css/style.css}" rel="stylesheet" type="text/css">
+</head>
+<body>
+<div th:insert="~{header :: header}"></div>
+
+<main class="main">
+  <div class="inner">
+    <div class="form_cover">
+      <h2 class="heading">ユーザーアイコン編集画面</h2>
+      <br>
+      <br>
+
+      <!-- 現在のアイコン -->
+      <div>
+        <img th:src="@{${user.avatar}}" alt="現在のアイコン">
+      </div>
+
+      <!-- アップロードフォーム -->
+      <form th:action="@{/users/{userId}/icon-update(userId=${userId})}" 
+            th:object="${userForm}" 
+            method="post" 
+            enctype="multipart/form-data">
+        <div class="form_field">
+          <label for="avatar">新しいアイコン画像を選択</label>
+          <br>
+          <input type="file" id="avatar" th:field="*{avatar}" required>
+        </div>
+
+        <div class="action">
+          <input class="form_btn" type="submit" value="アイコンを変更"/>
+        </div>
+      </form>
+
+      <div>
+        <a th:href="@{/users/{userId}(userId=${userId})}" class="nav_btn">マイページへ戻る</a>
+      </div>
+    </div>
+  </div>
+</main>
+
+<div th:insert="~{footer :: footer}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/users/signUp.html
+++ b/src/main/resources/templates/users/signUp.html
@@ -72,7 +72,12 @@
 
         <div class="field">
           <label for="prototype_image">アイコンの画像</label><br>
-          <input type="file" id="avatar_image" th:field="*{avatar}">
+          <input type="file" id="avatar" th:field="*{avatar}">
+        </div>
+
+        <div class="register-icon-preview-area">
+          <h2>アイコンプレビュー</h2>
+          <img id="preview-avatar" src="" alt="アップロード画像" class="register-icon-preview-img" style="display:none;">
         </div>
 
         <div class="action">
@@ -83,7 +88,7 @@
   </div>
 </main>
 
-
+<script src="/js/avatar_preview.js"></script>
 <div th:insert="~{footer :: footer}"></div>
 </body>
 </html>


### PR DESCRIPTION
## What

ユーザーアイコン編集機能の実装とアイコンプレビュー

## Why

- ユーザーアイコンのみの編集を可能にすることで、ユーザーの負担を軽減する
- アイコンのプレビューを表示することで、誤った画像の登録を防ぐ